### PR TITLE
Fix logging crash and UI null access

### DIFF
--- a/Colorful-UI/Scripts/3_Game/Systems/CuiLogger.c
+++ b/Colorful-UI/Scripts/3_Game/Systems/CuiLogger.c
@@ -15,7 +15,20 @@ class CuiLogger
     protected static string Timestamp()
     {
         int year, month, day, hour, minute;
-        GetGame().GetWorld().GetDate(year, month, day, hour, minute);
+
+        if (GetGame() && GetGame().GetWorld())
+        {
+            GetGame().GetWorld().GetDate(year, month, day, hour, minute);
+        }
+        else
+        {
+            GetYear(year);
+            GetMonth(month);
+            GetDay(day);
+            GetHour(hour);
+            GetMinute(minute);
+        }
+
         return string.Format("%1-%2-%3 %4:%5", year, month, day, hour, minute);
     }
 }

--- a/Colorful-UI/Scripts/3_Game/Systems/Loading.c
+++ b/Colorful-UI/Scripts/3_Game/Systems/Loading.c
@@ -73,7 +73,10 @@ modded class LoginTimeBase extends LoginScreenBase
     
     override void SetTime(int time) {
         super.SetTime(time);
-        m_LoadingMsg.SetText("CONNECTING TO SERVER IN " + time.ToString());
+        if (m_LoadingMsg)
+        {
+            m_LoadingMsg.SetText("CONNECTING TO SERVER IN " + time.ToString());
+        }
         CuiLogger.Log("LoginTimeBase SetTime " + time.ToString());
     }
  
@@ -160,8 +163,11 @@ modded class LoginQueueBase extends LoginScreenBase
         if (position != m_iPosition)
         {
             m_iPosition = position;
-            m_txtPosition.SetText("Position in Queue " + position.ToString());
-            m_txtPosition.SetColor(colorScheme.LoadingMsg());
+            if (m_txtPosition)
+            {
+                m_txtPosition.SetText("Position in Queue " + position.ToString());
+                m_txtPosition.SetColor(colorScheme.LoadingMsg());
+            }
             CuiLogger.Log("LoginQueueBase position " + position.ToString());
         }
     }


### PR DESCRIPTION
## Summary
- avoid null world in logger timestamp
- guard loading screen text widget usage

## Testing
- `git status --short`