### PR TITLE
Adds main menu video

### DIFF
--- a/Colorful-UI/GUI/layouts/menus/cui.mainMenu.layout
+++ b/Colorful-UI/GUI/layouts/menus/cui.mainMenu.layout
@@ -34,6 +34,19 @@ FrameWidgetClass mainmenu_root {
    "Transition width" 1
    Progress 0
   }
+  VideoWidgetClass MenuVideo {
+   ignorepointer 1
+   size 0.16 0.09
+   halign center_ref
+   valign center_ref
+   hexactpos 1
+   vexactpos 1
+   hexactsize 0
+   vexactsize 0
+   fixaspect outside
+   "clamp mode" clamp
+   "stretch mode" stretch_w_h
+  }
   FrameWidgetClass Shaders {
    visible 1
    clipchildren 0

--- a/Colorful-UI/Scripts/3_Game/UIConfig/Settings.c
+++ b/Colorful-UI/Scripts/3_Game/UIConfig/Settings.c
@@ -1,12 +1,12 @@
 // Constants.c v3.0.0
-static bool StartMainMenu      = false;  // If set to true, the main menu will be forced to show on startup.
+static bool StartMainMenu      = true;  // If set to true, the main menu will be forced to show on startup.
 static bool NoHints			   = false;  // If set to true, the hints will not be shown during load screens.
-static bool LoadVideo          = false;   // If set to true, a video will be shown during load screens along with tips.
+static bool LoadVideo          = true;   // If set to true, a video will be shown during load screens along with tips.
 static bool ShowDeadScreen     = false;  // If set to true, a custom game over screen will be shown when the player dies. if false, the default game over screen will be shown.
 static bool CuiDebug           = true;   // Turn on Colorful UI Debugging. This will show debug information in the console and log file.
 
 // The below two settings are not yet implemented.
-static bool MainMenuVideo      = false;  // If set to true, a video will be shown during Main Menu Screens along with tips.
+static bool EnableMenuVideo    = true;  // If set to true, a video will be shown during Main Menu Screens along with tips.
 static bool VideoDeathScreens  = false;  // If set to true, a random game over screen will be shown when the player dies.
 static bool RandomDeathScreens = false;  // If set to true, a random game over video that will be shown when the player dies.
 

--- a/Colorful-UI/Scripts/5_Mission/GUI/CUI/menus/MainMenu.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/CUI/menus/MainMenu.c
@@ -4,6 +4,7 @@ modded class MainMenu extends UIScriptedMenu
 	protected ButtonWidget m_Play, m_Exit, m_SettingsBtn, m_TutorialBtn, m_MessageBtn, m_PrioQ, m_Website, m_Discord, m_Twitter, m_Youtube, m_Reddit, m_Facebook, m_CharacterBtn;
 	protected Widget m_TopSpacer, m_BottomSpacer;
 	protected ProgressBarWidget m_LoadingBar;
+	protected VideoWidget m_MenuVid;
 
 	override Widget Init()
 	{
@@ -74,6 +75,21 @@ modded class MainMenu extends UIScriptedMenu
 			if (m_BottomSpacer) m_BottomSpacer.Show(false);
 		}
 		Branding.ApplyLogo(m_Logo);
+
+		#ifdef WORKBENCH
+		CuiLogger.Log("UiHintPanelLoading.BuildLayout() - Skipping video in Workbench mode");
+		#else
+			if (EnableMenuVideo) {
+				Class.CastTo(m_MenuVid, layoutRoot.FindAnyWidget("MenuVideo"));
+				if (m_MenuVid) {
+					if (!FileExist("$saves:" + m_MainMenuVideo))
+						CopyFile("Colorful-UI/GUI/video/" + m_MainMenuVideo, "$saves:" + m_MainMenuVideo);
+					m_MenuVid.Load("$saves:" + m_MainMenuVideo, true);
+					m_MenuVid.Play();
+				}
+			}
+		#endif
+
 		return layoutRoot;
 	}
 


### PR DESCRIPTION
Implements a video playback feature to the main menu screen, enriching the user experience.

Enables the video by default, and includes logic to copy the video file to the saves directory if it doesn't already exist.
Video playback is skipped when running in Workbench mode.
