### PR TITLE
Fixes dialog system bugs

### DIFF
--- a/Colorful-UI/GUI/layouts/components/cuibackdrop.layout
+++ b/Colorful-UI/GUI/layouts/components/cuibackdrop.layout
@@ -12,7 +12,6 @@ FrameWidgetClass CuiBackdropRoot {
  priority 999
  {
   ImageWidgetClass ImageWidget0 {
-   ignorepointer 1
    color 0.098 0.098 0.098 0.702
    size 1 1
    halign center_ref

--- a/Colorful-UI/Scripts/5_Mission/GUI/CUI/dialogs/Invite.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/CUI/dialogs/Invite.c
@@ -5,8 +5,11 @@
 // referenced a non-existent layout (`cui.invite.dialog.layout`) and silently
 // failed.
 //
-// This version delegates the visible UI to CuiDialog and keeps the vanilla
-// timer/connect logic intact via super calls.
+// This version delegates the visible UI to CuiDialog. Vanilla's 15s
+// auto-connect countdown is intentionally NOT armed (its CallLater lives in
+// vanilla Init(), which we replace) — instead the user chooses explicitly:
+// Connect performs the join (same calls vanilla makes at countdown expiry),
+// Cancel runs vanilla Cancel() to stay on the current session.
 
 modded class InviteMenu extends UIScriptedMenu
 {
@@ -36,9 +39,14 @@ modded class InviteMenu extends UIScriptedMenu
 
 	void DoConnect()
 	{
-		// Tell the menu to dismiss; vanilla connect logic will run on close.
-		// (For the test flow this just closes — the real auto-connect happens
-		// on the timer in vanilla Update().)
+		// Vanilla's only connect path is the countdown expiry inside
+		// Update() (invitemenu.c:78-85) — but the countdown CallLater is
+		// armed in vanilla Init(), which we replaced, so m_iTime stays at 15
+		// forever and that branch never fires. Perform the same join here.
+		string ip;
+		int port;
+		OnlineServices.GetInviteServerInfo(ip, port);
+		g_Game.GetCallQueue(CALL_CATEGORY_SYSTEM).Call(g_Game.ConnectFromJoin, ip, port);
 		Close();
 	}
 

--- a/Colorful-UI/Scripts/5_Mission/GUI/CUI/dialogs/Invite.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/CUI/dialogs/Invite.c
@@ -43,11 +43,24 @@ modded class InviteMenu extends UIScriptedMenu
 		// Update() (invitemenu.c:78-85) — but the countdown CallLater is
 		// armed in vanilla Init(), which we replaced, so m_iTime stays at 15
 		// forever and that branch never fires. Perform the same join here.
+		//
+		// Vanilla deliberately does NOT close InviteMenu at this point —
+		// ConnectFromJoin (dayzgame.c:2775) calls Connect(), which reads
+		// Connect(GetUIManager().GetMenu(), ...) (dayzgame.c:2685) to hand
+		// the still-open menu to the native connect/loading transition.
+		// GetCallQueue(...).Call() only enqueues the call for the queue's
+		// next Tick (P:\scripts\2_gamelib\tools.c:57, ticked every frame
+		// from OnUpdate at dayzgame.c:2982) — it does not run synchronously.
+		// Closing the menu here, before that Tick fires, would make
+		// GetUIManager().GetMenu() return the wrong (or no) menu once
+		// ConnectFromJoin actually executes. Queue Close() on the same
+		// queue, after ConnectFromJoin, so it only runs once the native
+		// call has already captured the menu.
 		string ip;
 		int port;
 		OnlineServices.GetInviteServerInfo(ip, port);
 		g_Game.GetCallQueue(CALL_CATEGORY_SYSTEM).Call(g_Game.ConnectFromJoin, ip, port);
-		Close();
+		g_Game.GetCallQueue(CALL_CATEGORY_SYSTEM).Call(this.Close);
 	}
 
 	void DoCancel()

--- a/Colorful-UI/Scripts/5_Mission/GUI/CUI/dialogs/ItemDropWarning.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/CUI/dialogs/ItemDropWarning.c
@@ -19,6 +19,7 @@ modded class WarningMenuBase extends UIScriptedMenu
 		// Hidden 1x1 placeholder so the engine has a layoutRoot to attach.
 		// The visible UI is owned by CuiDialog below.
 		layoutRoot = GetGame().GetWorkspace().CreateWidgets("Colorful-UI/GUI/layouts/dialogs/cui.dialog_stub.layout");
+		if (!layoutRoot) return null;
 
 		string body = GetText();
 		if (body == "") body = "An action will drop items from your character.";

--- a/Colorful-UI/Scripts/5_Mission/GUI/CUI/menus/MainMenu.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/CUI/menus/MainMenu.c
@@ -225,13 +225,8 @@ modded class MainMenu extends UIScriptedMenu
 	// top dialog instead of stacking another one.
 	override void Exit()
 	{
-		int n = CuiDialog.s_OpenDialogs.Count();
-		if (n > 0)
-		{
-			CuiDialog top = CuiDialog.s_OpenDialogs.Get(n - 1);
-			if (top) top.OnCancel();
+		if (CuiDialog.CancelTop())
 			return;
-		}
 		OpenExitDialog();
 	}
 

--- a/Colorful-UI/Scripts/5_Mission/GUI/CUI/options/Keybindings.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/CUI/options/Keybindings.c
@@ -133,6 +133,11 @@ modded class KeybindingsMenu extends UIScriptedMenu
 	// Replicated verbatim, ShowDialog -> CuiDialog. Vanilla source: line 247-271.
 	override void Back()
 	{
+		// Escape with a CuiDialog open cancels the dialog instead of running
+		// the back flow again (which would stack another confirm dialog).
+		if (CuiDialog.CancelTop())
+			return;
+
 		if (m_CurrentSettingKeyIndex != -1)
 		{
 			CancelEnteringKeybind();

--- a/Colorful-UI/Scripts/5_Mission/GUI/CUI/options/Options.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/CUI/options/Options.c
@@ -229,6 +229,12 @@ modded class OptionsMenu extends UIScriptedMenu
 
 	override void Back()
 	{
+		// Vanilla's IsDialogVisible guard doesn't know about CuiDialog, so
+		// without this check Escape would stack a new confirm dialog on each
+		// press. Treat Escape as Cancel on the open dialog instead.
+		if (CuiDialog.CancelTop())
+			return;
+
 		if (g_Game.GetUIManager().IsDialogVisible() || g_Game.GetUIManager().IsModalVisible())
 			return;
 

--- a/Colorful-UI/Scripts/5_Mission/GUI/Components/Backdrop.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/Components/Backdrop.c
@@ -1,7 +1,8 @@
 // CuiBackdrop
 // -----------------------------------------------------------------------------
 // Reusable full-screen dim overlay. Used by CuiDialog and any other UI that
-// needs a modal scrim.
+// needs a modal scrim. The tint image does NOT set ignorepointer, so the
+// scrim swallows clicks — UI underneath a dialog is not clickable.
 //
 //   m_Bd = new CuiBackdrop();         // uses layout-defined tint (default)
 //   m_Bd.SetTint(ARGB(...));          // override tint+alpha at runtime

--- a/Colorful-UI/Scripts/5_Mission/GUI/Components/Dialogs.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/Components/Dialogs.c
@@ -175,8 +175,25 @@ class CuiDialog
         return dlg;
     }
 
+    // If any dialog is open, cancel the topmost one and return true. Menus
+    // whose Back/Exit path can retrigger while a dialog is up (Escape) call
+    // this first so the key dismisses the dialog instead of stacking another.
+    static bool CancelTop()
+    {
+        int n = s_OpenDialogs.Count();
+        if (n == 0) return false;
+        CuiDialog top = s_OpenDialogs.Get(n - 1);
+        if (top) top.OnCancel();
+        return true;
+    }
+
     void OnConfirm()
     {
+        // Ignore clicks that land during the exit animation — the buttons
+        // stay alive (invisible) until DoClose disposes their handlers, and
+        // without this guard a second click re-fires the caller's callback.
+        if (m_Closing) return;
+
         // Fire the caller's callback BEFORE starting the exit animation. The
         // dialog is still alive (m_Closing not yet set), so the callback can
         // even open another dialog if it wants — that one stacks on top.
@@ -189,6 +206,8 @@ class CuiDialog
 
     void OnCancel()
     {
+        if (m_Closing) return;
+
         if (m_CallbackTarget && m_OnCancelMethod != "")
         {
             GetGame().GameScript.CallFunction(m_CallbackTarget, m_OnCancelMethod, null, 0);


### PR DESCRIPTION
Addresses several issues within the dialog system:
- **Prevents modal click-through**: Dialog backdrops now correctly intercept pointer events, ensuring UI elements beneath active modals are not interactable.
- **Corrects Invite menu connect flow**: Ensures the `InviteMenu` connects reliably by queuing `ConnectFromJoin` and its subsequent `Close` call, resolving issues where the menu would close prematurely or connect logic would fail.
- **Prevents Escape key stacking**: The `Escape` key now cancels the topmost dialog instead of triggering new confirmation dialogs in main menu, options, and keybindings screens.
- **Avoids double-firing dialog actions**: Adds safeguards to `CuiDialog` confirm/cancel callbacks, preventing unintended multiple executions if a user clicks rapidly during dialog exit animations.
- **Adds layout loading robustness**: Includes a null check during layout creation for the item drop warning dialog, preventing potential crashes.