### PR TITLE
Improves modded options tab integration and styling

### DIFF
--- a/Colorful-UI/GUI/layouts/options/cui.options_menu.layout
+++ b/Colorful-UI/GUI/layouts/options/cui.options_menu.layout
@@ -101,9 +101,7 @@ FrameWidgetClass settings_menu_root {
   FrameWidgetClass Tabber {
    ignorepointer 1
    position 0 0
-   size 0.9 0.9
-   halign center_ref
-   valign center_ref
+   size 1 1
    hexactpos 1
    vexactpos 1
    hexactsize 0
@@ -111,14 +109,14 @@ FrameWidgetClass settings_menu_root {
    priority 1
    scriptclass "TabberUI"
    {
-    GridSpacerWidgetClass TabControls {
+    SpacerWidgetClass TabControls {
      visible 1
      clipchildren 0
      ignorepointer 1
-     position 0 0
-     size 710 55
-     hexactpos 0
-     vexactpos 0
+     position 80 80
+     size 710 60
+     hexactpos 1
+     vexactpos 1
      hexactsize 1
      vexactsize 1
      "no focus" 1
@@ -126,8 +124,6 @@ FrameWidgetClass settings_menu_root {
      Margin 0
      "Size To Content H" 1
      "Size To Content V" 1
-     Columns 4
-     Rows 1
      {
       SpacerWidgetClass TabBar {
        clipchildren 1
@@ -470,41 +466,41 @@ FrameWidgetClass settings_menu_root {
     FrameWidgetClass Tab_0 {
      visible 1
      ignorepointer 1
-     size 0.8 900
-     valign bottom_ref
+     position 80 160
+     size 1760 800
      hexactpos 1
      vexactpos 1
-     hexactsize 0
+     hexactsize 1
      vexactsize 1
     }
     FrameWidgetClass Tab_1 {
      visible 0
      ignorepointer 1
-     size 0.8 900
-     valign bottom_ref
+     position 80 160
+     size 1760 800
      hexactpos 1
      vexactpos 1
-     hexactsize 0
+     hexactsize 1
      vexactsize 1
     }
     FrameWidgetClass Tab_2 {
      visible 0
      ignorepointer 1
-     size 0.8 900
-     valign bottom_ref
+     position 80 160
+     size 1760 800
      hexactpos 1
      vexactpos 1
-     hexactsize 0
+     hexactsize 1
      vexactsize 1
     }
     FrameWidgetClass Tab_3 {
      visible 0
      ignorepointer 1
-     size 0.8 900
-     valign bottom_ref
+     position 80 160
+     size 1760 800
      hexactpos 1
      vexactpos 1
-     hexactsize 0
+     hexactsize 1
      vexactsize 1
     }
    }

--- a/Colorful-UI/GUI/layouts/options/cui.options_menu.layout
+++ b/Colorful-UI/GUI/layouts/options/cui.options_menu.layout
@@ -8,6 +8,17 @@ FrameWidgetClass settings_menu_root {
  vexactsize 0
  priority 951
  {
+  TextWidgetClass version {
+   visible 0
+   ignorepointer 1
+   position 0 0
+   size 200 20
+   hexactpos 1
+   vexactpos 1
+   hexactsize 1
+   vexactsize 1
+   font "Colorful-UI/GUI/fonts/GB-Regular.fnt"
+  }
   VideoWidgetClass MenuVideo {
    ignorepointer 1
    size 0.16 0.09

--- a/Colorful-UI/Scripts/5_Mission/GUI/CUI/options/Keybindings.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/CUI/options/Keybindings.c
@@ -37,6 +37,7 @@ modded class KeybindingsMenu extends UIScriptedMenu
 
 		InitInputSortingMap();
 		CreateTabs();
+		CuiReskinTabs();
 		CreateGroupContainer();
 
 		InitPresets(-1, layoutRoot.FindAnyWidget("group_header"), input);
@@ -53,6 +54,30 @@ modded class KeybindingsMenu extends UIScriptedMenu
 		m_Undo.SetFlags(WidgetFlags.IGNOREPOINTER);
 
 		return layoutRoot;
+	}
+
+	// CreateTabs may resolve to another mod's AddTab (see TabberUI.c), which
+	// builds the tab controls from that mod's layout with the wrong font. The
+	// names are deterministic — same inputs vanilla CreateTabs reads — so
+	// rebuild every control from our layout with the same titles.
+	protected void CuiReskinTabs()
+	{
+		int tab_index = 0;
+		int sort_count = InputUtils.GetInputActionSortingMap().Count();
+		for (int i = 0; i < sort_count; i++)
+		{
+			if (InputUtils.GetInputActionSortingMap().GetElement(i) && InputUtils.GetInputActionSortingMap().GetElement(i).Count() > 0)
+			{
+				string group_name = GetUApi().SortingLocalization(InputUtils.GetInputActionSortingMap().GetKey(i));
+				m_Tabber.CuiReskinTabControl(tab_index, Widget.TranslateString("#" + group_name));
+				tab_index++;
+			}
+		}
+
+		if (InputUtils.GetUnsortedInputActions() && InputUtils.GetUnsortedInputActions().Count() > 0)
+		{
+			m_Tabber.CuiReskinTabControl(tab_index, Widget.TranslateString("#layout_pc_keybinding_unsorted"));
+		}
 	}
 
 	// The visible button text lives on a child widget, so colour that too.

--- a/Colorful-UI/Scripts/5_Mission/GUI/CUI/options/Options.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/CUI/options/Options.c
@@ -2,6 +2,19 @@ modded class OptionsMenu extends UIScriptedMenu
 {
 	private Widget m_Separator, m_shader, m_TopShader, m_BottomShader, m_MenuDivider, m_LoadingBar;
 
+	// Colorful-UI compiles last (see Scripts/config.cpp requiredAddons), so
+	// our Init is outermost and other mods' options-tab injections never run.
+	// Each known tab-injecting mod is recreated here, guarded by the compile
+	// flag that mod ships so standalone builds are unaffected. Their modded-
+	// class fields aren't visible across mods; we track our own.
+	#ifdef EXPANSIONMODCORE
+	protected ref OptionsMenuExpansion m_CuiExpansionTab;
+	#endif
+	#ifdef ADM_NVG_Mod
+	protected ref OptionsNVGMenu m_CuiNVGMenu;
+	protected int m_CuiNVGTabIndex = -1;
+	#endif
+
 	private bool IsMainMenuContext()
 	{
 		Mission m = GetGame().GetMission();
@@ -86,8 +99,41 @@ modded class OptionsMenu extends UIScriptedMenu
 		}
 		#endif
 
+		#ifdef EXPANSIONMODCORE
+		// Mirrors DayZ Expansion Core's own OptionsMenu.Init injection.
+		int cuiExpTabIndex = m_Tabber.AddTab("EXPANSION");
+		m_CuiExpansionTab = new OptionsMenuExpansion(layoutRoot.FindAnyWidget("Tab_" + cuiExpTabIndex), m_Details, m_Options, this);
+		#endif
+
+		#ifdef ADM_NVG_Mod
+		// Mirrors Admirals NVG Mod's injection — tab exists only while wearing
+		// powered-on NVGs, the same condition the mod itself uses.
+		PlayerBase nvgPlayer = PlayerBase.Cast(g_Game.GetPlayer());
+		if (nvgPlayer && nvgPlayer.IsNVGWorking())
+		{
+			m_CuiNVGTabIndex = m_Tabber.AddTab("NVG MENU");
+			m_CuiNVGMenu = new OptionsNVGMenu(layoutRoot.FindAnyWidget("Tab_" + m_CuiNVGTabIndex), m_Details, m_Options, this);
+		}
+		#endif
+
 		return layoutRoot;
 	}
+
+	#ifdef EXPANSIONMODCORE
+	// Expansion's own OnChanged/Apply forwarding checks its private tab field,
+	// which stays null because its Init never runs — forward to our recreated
+	// tab so Expansion settings enable Apply and actually apply.
+	override void OnChanged()
+	{
+		super.OnChanged();
+
+		if (m_CuiExpansionTab && m_CuiExpansionTab.IsChanged())
+		{
+			m_Apply.ClearFlags(WidgetFlags.IGNOREPOINTER);
+			ColorNormal(m_Apply);
+		}
+	}
+	#endif
 
 	// Row hover and disabled colouring.
 	override void ColorDisable(Widget w)
@@ -179,6 +225,11 @@ modded class OptionsMenu extends UIScriptedMenu
 		if (m_ControlsTab.IsChanged()) m_ControlsTab.Apply();
 		if (m_SoundsTab.IsChanged())   m_SoundsTab.Apply();
 		if (m_GameTab.IsChanged())     m_GameTab.Apply();
+
+		#ifdef EXPANSIONMODCORE
+		if (m_CuiExpansionTab && m_CuiExpansionTab.IsChanged())
+			m_CuiExpansionTab.Apply();
+		#endif
 
 		if (m_Options.IsChanged() || m_GameTab.IsChanged())
 		{

--- a/Colorful-UI/Scripts/5_Mission/GUI/Components/TabberUI.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/Components/TabberUI.c
@@ -1,4 +1,4 @@
-modded class TabberUI extends ScriptedWidgetEventHandler
+modded class TabberUI
 {
 	override void AlignTabbers()
 	{
@@ -89,6 +89,41 @@ modded class TabberUI extends ScriptedWidgetEventHandler
 		return false;
 	}
 
+	// Rebuild an existing tab control from our layout. Other mods (DayZ
+	// Expansion among them) replace AddTab with their own tab control layout
+	// and can compile after us, so their control wins at creation time. Menus
+	// we own call this afterwards to reclaim each control. TextWidget has no
+	// GetText, so the caller supplies the title.
+	void CuiReskinTabControl( int index, string name )
+	{
+		Widget old_control = m_TabControls.Get( index );
+		if ( !old_control )
+			return;
+
+		Widget container = m_TabControlsRoot.FindAnyWidget( "Tab_Control_Container" );
+		if ( !container )
+			return;
+
+		string cname = old_control.GetName();
+
+		Widget control = GetGame().GetWorkspace().CreateWidgets( "Colorful-UI/GUI/layouts/components/tabber_prefab/cui.tab_control.layout", container );
+		TextWidget control_text = TextWidget.Cast( control.FindAnyWidget( "Tab_Control_x_Title" ) );
+
+		control.SetName( cname );
+		control_text.SetName( cname + "_Title" );
+		control.FindAnyWidget( "Tab_Control_x_Background" ).SetName( cname + "_Background" );
+		control_text.SetText( name );
+		control.SetHandler( this );
+
+		m_TabControls.Set( index, control );
+		old_control.Unlink();
+
+		if ( index == m_SelectedIndex )
+			SelectTabControl( index );
+
+		AlignTabbers();
+	}
+
 	override int AddTab( string name )
 	{
 		int new_index = m_Tabs.Count();
@@ -106,9 +141,9 @@ modded class TabberUI extends ScriptedWidgetEventHandler
 		control.SetHandler( this );
 		m_TabControls.Insert( new_index, control );
 		m_Tabs.Insert( new_index, tab );
-		
+
 		AlignTabbers();
-		
+
 		return new_index;
 	}
 }

--- a/Colorful-UI/Scripts/5_Mission/GUI/Components/TabberUI.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/Components/TabberUI.c
@@ -49,6 +49,12 @@ modded class TabberUI
 			tab_child = tab_child.GetSibling();
 		}
 
+		// Vanilla ends by resizing the tab-bar root to fit every tab. Without
+		// it, layouts whose bar has no scroller (options) clip tabs added past
+		// the static ones — mod-injected tabs exist but render out of view.
+		m_TabControlsRoot.GetSize( x, y );
+		m_TabControlsRoot.SetSize( total_size, y );
+
 		tab_controls_container.Update();
 		if ( tab_controls_scroller )
 			tab_controls_scroller.Update();

--- a/Colorful-UI/Scripts/config.cpp
+++ b/Colorful-UI/Scripts/config.cpp
@@ -4,7 +4,25 @@ class CfgPatches
 	class ColorfulUI_Scripts
 	{
         requiredVersion = 0.1;
-		requiredAddons[] = {"DZ_Data","DZ_Scripts","DZ_Sounds_Effects","ColorfulUI_GUI"};
+		// The breadth of this list is load-bearing: script compile order
+		// follows the addon dependency graph, and a UI mod must compile AFTER
+		// other mods so its modded TabberUI.AddTab is the one that builds
+		// injected tabs (that's where the tab font comes from). All entries
+		// are vanilla game addons — no mod dependencies.
+		requiredAddons[] =
+		{
+			"DZ_Data","DZ_Scripts","DZ_Sounds_Effects","ColorfulUI_GUI",
+			"DZ_Characters","DZ_Characters_Headgear","DZ_Characters_Tops","DZ_Characters_Vests",
+			"DZ_Characters_Pants","DZ_Characters_Belts","DZ_Characters_Backpacks","DZ_Characters_Heads",
+			"DZ_Characters_Zombies","DZ_Gear_Optics","DZ_Gear_Tools","DZ_Radio","DZ_Gear_Food",
+			"DZ_Gear_Medical","DZ_Gear_Containers","DZ_Gear_Consumables","DZ_Gear_Cooking",
+			"DZ_Gear_Navigation","DZ_Gear_Drinks","DZ_Gear_Camping","DZ_Gear_Crafting",
+			"DZ_Animals","DZ_AI","DZ_Weapons_Melee","DZ_Weapons_Projectiles","DZ_Weapons_Magazines",
+			"DZ_Weapons_Firearms","DZ_Weapons_Explosives","DZ_Weapons_Ammunition","DZ_Weapons_Shotguns",
+			"DZ_Weapons_Archery","DZ_Weapons_Optics","DZ_Weapons_Supports","DZ_Weapons_Muzzles",
+			"DZ_Weapons_Attachments_Data","DZ_Weapons_Archery_Crossbow","DZ_Pistols",
+			"DZ_Structures","DZ_Vehicles_Parts","DZ_Vehicles_Wheeled","DZ_Sounds_Weapons"
+		};
 	};
 };
 


### PR DESCRIPTION
Ensures Colorful-UI's options and keybinding menus correctly integrate with other mods and maintain consistent styling.

*   **Establishes Script Compile Order:** Adjusts `config.cpp` to ensure Colorful-UI's script overrides, particularly for `TabberUI`, take precedence over other mods, guaranteeing the correct UI component creation.
*   **Re-integrates Modded Tabs:** Explicitly re-injects options tabs for known mods (e.g., DayZ Expansion, Admirals NVG Mod) within Colorful-UI's `OptionsMenu.Init` to ensure they are present and functional when CUI compiles last.
*   **Enables Tab Control Reskinning:** Introduces a `CuiReskinTabControl` method in `TabberUI` to dynamically rebuild tab buttons using Colorful-UI's layout and fonts, addressing instances where other mods might override tab creation (e.g., in the Keybindings menu).
*   **Updates Options Menu Layout:** Refines the `cui.options_menu.layout` to align with vanilla DayZ's tabber geometry, ensuring mod-injected tabs display correctly and providing proper spacing for content.
*   **Restores Tab Visibility:** Corrects a missing resize operation in `TabberUI.AlignTabbers` to prevent mod-added tabs from being clipped or invisible.
*   **Ensures Apply Functionality:** Forwards `OnChanged` and `Apply` calls for re-integrated mod tabs (e.g., Expansion) to ensure their settings can be saved.
*   **Adds Version Widget:** Incorporates a `version` text widget in the options menu layout, consistent with vanilla expectations.