### PR TITLE
Improves modded options tab integration and styling

### DIFF
--- a/Colorful-UI/Scripts/3_Game/Config/Settings.c
+++ b/Colorful-UI/Scripts/3_Game/Config/Settings.c
@@ -1,5 +1,5 @@
 // Constants.c v3.0.0
-static bool StartMainMenu      = true;  // If set to true, the main menu will be forced to show on startup.
+static bool StartMainMenu      = false;  // If set to true, the main menu will be forced to show on startup.
 static bool ErrorTestScreen    = false; // If set to true, MainMenu boots into the error/dialog test harness (cui.errortest.layout) instead of the normal main menu. Debug/QA only.
 static bool NoHints			   = false;  // If set to true, the hints will not be shown during load screens.
 static bool UseImagesets       = false;   // If true, hints.json entries with m_ImageSet/m_ImageName load from the registered `backgrounds` imageset; otherwise m_ImagePath is used.

--- a/Colorful-UI/Scripts/5_Mission/GUI/CUI/options/Options.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/CUI/options/Options.c
@@ -68,16 +68,8 @@ modded class OptionsMenu extends UIScriptedMenu
 		Widget tabBarBg = layoutRoot.FindAnyWidget("Tab_Control_Container");
 		if (tabBarBg) tabBarBg.SetColor(ARGB(140, 0, 0, 0));
 
-		// Game-tab section headers — color via OptionHeaders so they follow
-		// brand. All four tabs are constructed up-front so widgets exist here.
-		TextWidget genHeader  = TextWidget.Cast(layoutRoot.FindAnyWidget("general_text"));
-		TextWidget camHeader  = TextWidget.Cast(layoutRoot.FindAnyWidget("camera_text"));
-		TextWidget hudHeader  = TextWidget.Cast(layoutRoot.FindAnyWidget("hud_text"));
-		TextWidget chatHeader = TextWidget.Cast(layoutRoot.FindAnyWidget("chat_text"));
-		if (genHeader)  genHeader.SetColor(colorScheme.OptionHeaders());
-		if (camHeader)  camHeader.SetColor(colorScheme.OptionHeaders());
-		if (hudHeader)  hudHeader.SetColor(colorScheme.OptionHeaders());
-		if (chatHeader) chatHeader.SetColor(colorScheme.OptionHeaders());
+		// Section headers inside tabs stay uncolored (white, like every other
+		// tab's) — one consistent look, nothing to restyle per foreign mod.
 
 		m_ModalLock = false;
 		m_CanApplyOrReset = false;
@@ -103,6 +95,12 @@ modded class OptionsMenu extends UIScriptedMenu
 		// Mirrors DayZ Expansion Core's own OptionsMenu.Init injection.
 		int cuiExpTabIndex = m_Tabber.AddTab("EXPANSION");
 		m_CuiExpansionTab = new OptionsMenuExpansion(layoutRoot.FindAnyWidget("Tab_" + cuiExpTabIndex), m_Details, m_Options, this);
+
+		// Their settings column is a hard 600px-wide scroll; our tabs use 650.
+		// Match it so every tab's content reads the same width.
+		Widget expScroll = layoutRoot.FindAnyWidget("expansion_settings_scroll");
+		if (expScroll)
+			expScroll.SetSize(650, 1);
 		#endif
 
 		#ifdef ADM_NVG_Mod


### PR DESCRIPTION
Ensures Colorful-UI's options and keybinding menus correctly integrate with other mods and maintain consistent styling.

*   **Establishes Script Compile Order:** Adjusts `config.cpp` to ensure Colorful-UI's script overrides, particularly for `TabberUI`, take precedence over other mods, guaranteeing the correct UI component creation.
*   **Re-integrates Modded Tabs:** Explicitly re-injects options tabs for known mods (e.g., DayZ Expansion, Admirals NVG Mod) within Colorful-UI's `OptionsMenu.Init` to ensure they are present and functional when CUI compiles last.
*   **Enables Tab Control Reskinning:** Introduces a `CuiReskinTabControl` method in `TabberUI` to dynamically rebuild tab buttons using Colorful-UI's layout and fonts, addressing instances where other mods might override tab creation (e.g., in the Keybindings menu).
*   **Updates Options Menu Layout:** Refines the `cui.options_menu.layout` to align with vanilla DayZ's tabber geometry, ensuring mod-injected tabs display correctly and providing proper spacing for content.
*   **Restores Tab Visibility:** Corrects a missing resize operation in `TabberUI.AlignTabbers` to prevent mod-added tabs from being clipped or invisible.
*   **Ensures Apply Functionality:** Forwards `OnChanged` and `Apply` calls for re-integrated mod tabs (e.g., Expansion) to ensure their settings can be saved.
*   **Adds Version Widget:** Incorporates a `version` text widget in the options menu layout, consistent with vanilla expectations.