### PR TITLE
Tab bar overflow scrolls on options + keybindings

### DIFF
--- a/Colorful-UI/GUI/layouts/options/cui.options_menu.layout
+++ b/Colorful-UI/GUI/layouts/options/cui.options_menu.layout
@@ -109,54 +109,33 @@ FrameWidgetClass settings_menu_root {
    priority 1
    scriptclass "TabberUI"
    {
-    SpacerWidgetClass TabControls {
+    WrapSpacerWidgetClass TabControls {
      visible 1
      clipchildren 0
      ignorepointer 1
      position 80 80
-     size 710 60
+     size 0.7 65
      hexactpos 1
      vexactpos 1
-     hexactsize 1
+     hexactsize 0
      vexactsize 1
-     "no focus" 1
      Padding 0
      Margin 0
      "Size To Content H" 1
      "Size To Content V" 1
      {
-      SpacerWidgetClass TabBar {
+      ScrollWidgetClass Tab_Control_Scroller {
        clipchildren 1
-       ignorepointer 1
-       position 0 0
-       size 1 1
+       size 1 75
        hexactpos 1
        vexactpos 1
        hexactsize 0
-       vexactsize 0
-       "no focus" 1
-       Padding 0
-       Margin 0
-       "Size To Content H" 1
-       "Size To Content V" 1
+       vexactsize 1
+       scaled 1
+       "Scrollbar H" 1
        {
-        ImageWidgetClass Tabs_Background {
-         visible 0
-         ignorepointer 1
-         color 1 1 1 0.5098
-         position 0 0
-         size 1 1
-         hexactpos 0
-         vexactpos 0
-         hexactsize 0
-         vexactsize 0
-         imageTexture "{5A89D58DD2276E85}gui/textures/serratedblack2.edds"
-         mode blend
-         "src alpha" 1
-         "clamp mode" clamp
-         "stretch mode" stretch_w_h
-        }
         GridSpacerWidgetClass Tab_Control_Container {
+         visible 1
          ignorepointer 1
          color 0 0 0 0.549
          position 0 0
@@ -171,250 +150,249 @@ FrameWidgetClass settings_menu_root {
          Padding 0
          Margin 0
          "Size To Content H" 1
-         "Size To Content V" 1
-         Columns 10
+         Columns 50
          Rows 1
          {
-          PanelWidgetClass Tab_Control_0 {
-           visible 1
-           clipchildren 1
-           color 0 0 0 0.549
-           position 0 0
-           size 160 1
-           hexactpos 1
-           vexactpos 1
-           hexactsize 1
-           vexactsize 0
-           priority 200
-           userID 0
-           style DayZDefaultPanel
-           "no focus" 1
-           "next down" "XComboBoxWidget1"
-           {
-            TextWidgetClass Tab_Control_0_Title {
-             ignorepointer 1
+           PanelWidgetClass Tab_Control_0 {
+             visible 1
+             clipchildren 1
+             color 0 0 0 0.549
              position 0 0
-             size 1 0.42
-             halign center_ref
-             valign center_ref
-             hexactpos 1
-             vexactpos 1
-             hexactsize 0
-             vexactsize 0
-             priority 250
-             text "#STR_settings_menu_root_Tabber_TabControls_TabBar_Tab_Control_Container_Tab_Control_0_Tab_Control_0_Title0"
-             font "Colorful-UI/GUI/fonts/GB-Regular.fnt"
-             "size to text h" 1
-             "size to text v" 0
-             "text halign" center
-             "text valign" center
-            }
-            ImageWidgetClass Tab_Control_0_Background {
-             visible 0
-             disabled 0
-             inheritalpha 0
-             ignorepointer 1
-             color 1 1 1 0.7843
-             position 0 0
-             size 710 1
+             size 160 1
              hexactpos 1
              vexactpos 1
              hexactsize 1
              vexactsize 0
-             draggable 0
-             imageTexture "{5A89D58DD2276E85}gui/textures/serratedblack2.edds"
-             mode blend
-             "src alpha" 1
-             "clamp mode" clamp
-             "stretch mode" stretch_w_h
-             "flip u" 0
-             "flip v" 0
-             filter 1
-             nocache 0
+             priority 200
+             userID 0
+             style DayZDefaultPanel
+             "no focus" 1
+             "next down" "XComboBoxWidget1"
+             {
+              TextWidgetClass Tab_Control_0_Title {
+               ignorepointer 1
+               position 0 0
+               size 1 0.42
+               halign center_ref
+               valign center_ref
+               hexactpos 1
+               vexactpos 1
+               hexactsize 0
+               vexactsize 0
+               priority 250
+               text "#STR_settings_menu_root_Tabber_TabControls_TabBar_Tab_Control_Container_Tab_Control_0_Tab_Control_0_Title0"
+               font "Colorful-UI/GUI/fonts/GB-Regular.fnt"
+               "size to text h" 1
+               "size to text v" 0
+               "text halign" center
+               "text valign" center
+              }
+              ImageWidgetClass Tab_Control_0_Background {
+               visible 0
+               disabled 0
+               inheritalpha 0
+               ignorepointer 1
+               color 1 1 1 0.7843
+               position 0 0
+               size 710 1
+               hexactpos 1
+               vexactpos 1
+               hexactsize 1
+               vexactsize 0
+               draggable 0
+               imageTexture "{5A89D58DD2276E85}gui/textures/serratedblack2.edds"
+               mode blend
+               "src alpha" 1
+               "clamp mode" clamp
+               "stretch mode" stretch_w_h
+               "flip u" 0
+               "flip v" 0
+               filter 1
+               nocache 0
+              }
+             }
             }
-           }
-          }
-          PanelWidgetClass Tab_Control_1 {
-           visible 1
-           clipchildren 1
-           color 0 0 0 0
-           position 0 0
-           size 170 1
-           hexactpos 1
-           vexactpos 1
-           hexactsize 1
-           vexactsize 0
-           priority 200
-           userID 0
-           style DayZDefaultPanel
-           "no focus" 1
-           "next down" "XComboBoxWidget1"
-           {
-            TextWidgetClass Tab_Control_1_Title {
-             ignorepointer 1
+           PanelWidgetClass Tab_Control_1 {
+             visible 1
+             clipchildren 1
+             color 0 0 0 0
              position 0 0
-             size 1 0.42
-             halign center_ref
-             valign center_ref
-             hexactpos 1
-             vexactpos 1
-             hexactsize 0
-             vexactsize 0
-             priority 250
-             text "#STR_settings_menu_root_Tabber_TabControls_TabBar_Tab_Control_Container_Tab_Control_1_Tab_Control_1_Title0"
-             font "Colorful-UI/GUI/fonts/GB-Regular.fnt"
-             "size to text h" 1
-             "size to text v" 0
-             "text halign" center
-             "text valign" center
-            }
-            ImageWidgetClass Tab_Control_1_Background {
-             visible 0
-             disabled 0
-             inheritalpha 0
-             ignorepointer 1
-             color 1 1 1 0.7843
-             position -160 0
-             size 710 1
+             size 170 1
              hexactpos 1
              vexactpos 1
              hexactsize 1
              vexactsize 0
-             draggable 0
-             imageTexture "{5A89D58DD2276E85}gui/textures/serratedblack2.edds"
-             mode blend
-             "src alpha" 1
-             "clamp mode" clamp
-             "stretch mode" stretch_w_h
-             "flip u" 0
-             "flip v" 0
-             filter 1
-             nocache 0
+             priority 200
+             userID 0
+             style DayZDefaultPanel
+             "no focus" 1
+             "next down" "XComboBoxWidget1"
+             {
+              TextWidgetClass Tab_Control_1_Title {
+               ignorepointer 1
+               position 0 0
+               size 1 0.42
+               halign center_ref
+               valign center_ref
+               hexactpos 1
+               vexactpos 1
+               hexactsize 0
+               vexactsize 0
+               priority 250
+               text "#STR_settings_menu_root_Tabber_TabControls_TabBar_Tab_Control_Container_Tab_Control_1_Tab_Control_1_Title0"
+               font "Colorful-UI/GUI/fonts/GB-Regular.fnt"
+               "size to text h" 1
+               "size to text v" 0
+               "text halign" center
+               "text valign" center
+              }
+              ImageWidgetClass Tab_Control_1_Background {
+               visible 0
+               disabled 0
+               inheritalpha 0
+               ignorepointer 1
+               color 1 1 1 0.7843
+               position -160 0
+               size 710 1
+               hexactpos 1
+               vexactpos 1
+               hexactsize 1
+               vexactsize 0
+               draggable 0
+               imageTexture "{5A89D58DD2276E85}gui/textures/serratedblack2.edds"
+               mode blend
+               "src alpha" 1
+               "clamp mode" clamp
+               "stretch mode" stretch_w_h
+               "flip u" 0
+               "flip v" 0
+               filter 1
+               nocache 0
+              }
+             }
             }
-           }
-          }
-          PanelWidgetClass Tab_Control_2 {
-           visible 1
-           clipchildren 1
-           color 0 0 0 0
-           position 0 0
-           size 160 1
-           hexactpos 1
-           vexactpos 1
-           hexactsize 1
-           vexactsize 0
-           priority 200
-           userID 0
-           style DayZDefaultPanel
-           "no focus" 1
-           "next down" "XComboBoxWidget1"
-           {
-            TextWidgetClass Tab_Control_2_Title {
-             ignorepointer 1
+           PanelWidgetClass Tab_Control_2 {
+             visible 1
+             clipchildren 1
+             color 0 0 0 0
              position 0 0
-             size 1 0.42
-             halign center_ref
-             valign center_ref
-             hexactpos 1
-             vexactpos 1
-             hexactsize 0
-             vexactsize 0
-             priority 250
-             text "#STR_settings_menu_root_Tabber_TabControls_TabBar_Tab_Control_Container_Tab_Control_2_Tab_Control_2_Title0"
-             font "Colorful-UI/GUI/fonts/GB-Regular.fnt"
-             "size to text h" 1
-             "size to text v" 0
-             "text halign" center
-             "text valign" center
-            }
-            ImageWidgetClass Tab_Control_2_Background {
-             visible 0
-             disabled 0
-             inheritalpha 0
-             ignorepointer 1
-             color 1 1 1 0.7843
-             position -330 0
-             size 710 1
+             size 160 1
              hexactpos 1
              vexactpos 1
              hexactsize 1
              vexactsize 0
-             draggable 0
-             imageTexture "{5A89D58DD2276E85}gui/textures/serratedblack2.edds"
-             mode blend
-             "src alpha" 1
-             "clamp mode" clamp
-             "stretch mode" stretch_w_h
-             "flip u" 0
-             "flip v" 0
-             filter 1
-             nocache 0
+             priority 200
+             userID 0
+             style DayZDefaultPanel
+             "no focus" 1
+             "next down" "XComboBoxWidget1"
+             {
+              TextWidgetClass Tab_Control_2_Title {
+               ignorepointer 1
+               position 0 0
+               size 1 0.42
+               halign center_ref
+               valign center_ref
+               hexactpos 1
+               vexactpos 1
+               hexactsize 0
+               vexactsize 0
+               priority 250
+               text "#STR_settings_menu_root_Tabber_TabControls_TabBar_Tab_Control_Container_Tab_Control_2_Tab_Control_2_Title0"
+               font "Colorful-UI/GUI/fonts/GB-Regular.fnt"
+               "size to text h" 1
+               "size to text v" 0
+               "text halign" center
+               "text valign" center
+              }
+              ImageWidgetClass Tab_Control_2_Background {
+               visible 0
+               disabled 0
+               inheritalpha 0
+               ignorepointer 1
+               color 1 1 1 0.7843
+               position -330 0
+               size 710 1
+               hexactpos 1
+               vexactpos 1
+               hexactsize 1
+               vexactsize 0
+               draggable 0
+               imageTexture "{5A89D58DD2276E85}gui/textures/serratedblack2.edds"
+               mode blend
+               "src alpha" 1
+               "clamp mode" clamp
+               "stretch mode" stretch_w_h
+               "flip u" 0
+               "flip v" 0
+               filter 1
+               nocache 0
+              }
+             }
             }
-           }
-          }
-          PanelWidgetClass Tab_Control_3 {
-           visible 1
-           clipchildren 1
-           color 0 0 0 0
-           position 0 0
-           size 220 1
-           hexactpos 1
-           vexactpos 1
-           hexactsize 1
-           vexactsize 0
-           priority 200
-           userID 0
-           style DayZDefaultPanel
-           "no focus" 1
-           "next down" "XComboBoxWidget1"
-           {
-            TextWidgetClass Tab_Control_3_Title {
-             ignorepointer 1
+           PanelWidgetClass Tab_Control_3 {
+             visible 1
+             clipchildren 1
+             color 0 0 0 0
              position 0 0
-             size 1 0.42
-             halign center_ref
-             valign center_ref
-             hexactpos 1
-             vexactpos 1
-             hexactsize 0
-             vexactsize 0
-             priority 250
-             text "#STR_settings_menu_root_Tabber_TabControls_TabBar_Tab_Control_Container_Tab_Control_3_Tab_Control_3_Title0"
-             font "Colorful-UI/GUI/fonts/GB-Regular.fnt"
-             "size to text h" 1
-             "text halign" center
-             "text valign" center
-            }
-            ImageWidgetClass Tab_Control_3_Background {
-             visible 0
-             disabled 0
-             inheritalpha 0
-             ignorepointer 1
-             color 1 1 1 0.7843
-             position -490 0
-             size 710 1
+             size 220 1
              hexactpos 1
              vexactpos 1
              hexactsize 1
              vexactsize 0
-             draggable 0
-             imageTexture "{5A89D58DD2276E85}gui/textures/serratedblack2.edds"
-             mode blend
-             "src alpha" 1
-             "clamp mode" clamp
-             "stretch mode" stretch_w_h
-             "flip u" 0
-             "flip v" 0
-             filter 1
-             nocache 0
+             priority 200
+             userID 0
+             style DayZDefaultPanel
+             "no focus" 1
+             "next down" "XComboBoxWidget1"
+             {
+              TextWidgetClass Tab_Control_3_Title {
+               ignorepointer 1
+               position 0 0
+               size 1 0.42
+               halign center_ref
+               valign center_ref
+               hexactpos 1
+               vexactpos 1
+               hexactsize 0
+               vexactsize 0
+               priority 250
+               text "#STR_settings_menu_root_Tabber_TabControls_TabBar_Tab_Control_Container_Tab_Control_3_Tab_Control_3_Title0"
+               font "Colorful-UI/GUI/fonts/GB-Regular.fnt"
+               "size to text h" 1
+               "text halign" center
+               "text valign" center
+              }
+              ImageWidgetClass Tab_Control_3_Background {
+               visible 0
+               disabled 0
+               inheritalpha 0
+               ignorepointer 1
+               color 1 1 1 0.7843
+               position -490 0
+               size 710 1
+               hexactpos 1
+               vexactpos 1
+               hexactsize 1
+               vexactsize 0
+               draggable 0
+               imageTexture "{5A89D58DD2276E85}gui/textures/serratedblack2.edds"
+               mode blend
+               "src alpha" 1
+               "clamp mode" clamp
+               "stretch mode" stretch_w_h
+               "flip u" 0
+               "flip v" 0
+               filter 1
+               nocache 0
+              }
+             }
             }
-           }
-          }
          }
         }
        }
       }
-      FrameWidgetClass ConsoleControls {
+        FrameWidgetClass ConsoleControls {
        visible 0
        clipchildren 0
        ignorepointer 1

--- a/Colorful-UI/Scripts/5_Mission/GUI/Components/TabberUI.c
+++ b/Colorful-UI/Scripts/5_Mission/GUI/Components/TabberUI.c
@@ -49,11 +49,11 @@ modded class TabberUI
 			tab_child = tab_child.GetSibling();
 		}
 
-		// Vanilla ends by resizing the tab-bar root to fit every tab. Without
-		// it, layouts whose bar has no scroller (options) clip tabs added past
-		// the static ones — mod-injected tabs exist but render out of view.
-		m_TabControlsRoot.GetSize( x, y );
-		m_TabControlsRoot.SetSize( total_size, y );
+		// The root keeps its layout width on purpose: both the options and
+		// keybindings layouts wrap Tab_Control_Container in Tab_Control_Scroller,
+		// so an over-wide container overflows INSIDE the scroller and scrolls.
+		// Growing the root to total_size (vanilla's tail) would let the bar
+		// stretch past the screen and the scroller would never engage.
 
 		tab_controls_container.Update();
 		if ( tab_controls_scroller )


### PR DESCRIPTION
Options menu tab bar rebuilt to the keybindings structure (WrapSpacer >
Tab_Control_Scroller > Tab_Control_Container, 50-column single row),
replacing the fixed-width TabBar wrapper. Drop vanilla's AlignTabbers
tail that grew the tab-bar root to total tab width — the root now keeps
its layout width so an over-wide container overflows inside the scroller
and the horizontal scrollbar engages instead of the bar stretching
offscreen. Verified in-game with 20+ injected tabs on both pages.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
